### PR TITLE
Containerize application using Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,8 @@ pipeline:
     environment:
       - CGO_ENABLED=0
     commands:
-      - export BUILD_DATE=$(date)
+      - BUILD_DATE=$(date)
+      - export BUILD_DATE
       - go vet
       - go test -cover -coverprofile=coverage.out
       - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ pipeline:
       - export BUILD_DATE
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=$BUILD_DATE"
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
 
   publish_latest:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,10 +8,10 @@ pipeline:
     environment:
       - CGO_ENABLED=0
     commands:
-      - export DATE=$(date)
+      - export BUILD_DATE=$(date)
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${DATE}"
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
 
   publish_latest:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,15 +10,15 @@ pipeline:
     commands:
       - BUILD_DATE=$(date)
       - export BUILD_DATE
-      - printenv
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - BUILD_DATE=$(date) go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=$BUILD_DATE"
 
   publish_latest:
     image: plugins/docker
     repo: tonglil/frep
     tags: ["latest", "1"]
+    secrets: [docker_username, docker_password]
     when:
       branch: master
       event: push

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,30 @@
+workspace:
+  base: /go
+  path: src/github.com/subchen/frep
+
+pipeline:
+  test:
+    image: golang:1.8
+    environment:
+      - CGO_ENABLED=0
+    commands:
+      - export DATE=$(date)
+      - go vet
+      - go test -cover -coverprofile=coverage.out
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${DATE}"
+
+  publish_latest:
+    image: plugins/docker
+    repo: tonglil/frep
+    tags: ["latest", "1"]
+    when:
+      branch: master
+      event: push
+
+  publish_tag:
+    image: plugins/docker
+    repo: tonglil/frep
+    tags: ["latest", "${DRONE_TAG}"]
+    secrets: [docker_username, docker_password]
+    when:
+      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
     commands:
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - BUILD_DATE=$(date "+%Y-%m-%d") go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=$(date +%Y-%m-%d)"
 
   publish_latest:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pipeline:
     environment:
       - CGO_ENABLED=0
     commands:
-      - BUILD_DATE=$(date)
+      - BUILD_DATE=$(date "+%Y-%m-%d")
       - export BUILD_DATE
       - go vet
       - go test -cover -coverprofile=coverage.out

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,9 +10,10 @@ pipeline:
     commands:
       - BUILD_DATE=$(date)
       - export BUILD_DATE
+      - printenv
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
+      - BUILD_DATE=$(date) go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
 
   publish_latest:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
     commands:
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=$(date +%Y-%m-%d)"
+      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildGitCommit=${DRONE_COMMIT_SHA} -X main.BuildDate=$(date +%Y-%m-%d)"
 
   publish_latest:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,11 +8,9 @@ pipeline:
     environment:
       - CGO_ENABLED=0
     commands:
-      - BUILD_DATE=$(date "+%Y-%m-%d")
-      - export BUILD_DATE
       - go vet
       - go test -cover -coverprofile=coverage.out
-      - go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
+      - BUILD_DATE=$(date "+%Y-%m-%d") go build -a -ldflags "-X main.BuildVersion=${DRONE_TAG} -X main.BuildGitRev=${DRONE_COMMIT} -X main.BuildDate=${BUILD_DATE}"
 
   publish_latest:
     image: plugins/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+ADD frep /bin/
+
+ENTRYPOINT ["frep"]

--- a/main.go
+++ b/main.go
@@ -184,9 +184,10 @@ frep nginx.conf.in --load config.json --overwrite
 
 	if BuildVersion != "" {
 		app.Version = BuildVersion + "-" + BuildGitRev
-		app.BuildGitCommit = BuildGitCommit
-		app.BuildDate = BuildDate
 	}
+
+	app.BuildGitCommit = BuildGitCommit
+	app.BuildDate = BuildDate
 
 	app.Action = func(c *cli.Context) {
 		if c.NArg() == 0 {


### PR DESCRIPTION
Closes #3.

Also changed the versioning setup so that it doesn't rely on a tag to populate other version info.

You can own this by:
- Modifying the `repo: tonglil/frep` to your own user on Docker hub
- Sign up for Drone at https://beta.drone.io/
- Activate this repo at https://beta.drone.io/subchen/frep
- Add your Docker hub login info as `docker_username` and `docker_password` in https://beta.drone.io/subchen/frep/secrets