### PR TITLE
Make binary portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build: \
     build-windows
 
 build-linux: clean fmt
-	@ GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-$(VERSION)-linux-amd64
+	@ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-$(VERSION)-linux-amd64
 
 build-darwin: clean fmt
 	@ GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-$(VERSION)-darwin-amd64


### PR DESCRIPTION
This may fix subchen/frep#9


After reading https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324 i think this PR addresses the issue.

Please review, i am not a Go expert :).