### PR TITLE
Add include and fileExists functions. Fixes regex functions argument order. Adds strict flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ OPTIONS:
        --no-sys-env        exclude system environments, default false
        --overwrite         overwrite if destination file exists
        --dryrun            just output result to console instead of file
+       --strict            exit on any error during template processing
        --delims value      template tag delimiters (default: {{:}})
        --help              print this usage
        --version           print version information
@@ -220,6 +221,12 @@ More funcs added:
 - fileLastModified
 - fileGetBytes
 - fileGetString
+- fileExists
+- include
+- pipeline compatible regex functions from sprig 
+    - reReplaceAll
+    - reReplaceAllLiteral
+    - reSplit
 
 Sample of nginx.conf.in
 
@@ -231,7 +238,7 @@ server {
     index index.html index.htm;
 
     location /api {
-        access_log off;
+        {{ include "shared/log.nginx" | indent 8 | trim }}
         proxy_pass http://backend;
     }
 }

--- a/examples/locations/api.nginx
+++ b/examples/locations/api.nginx
@@ -1,0 +1,10 @@
+location /api {
+    {{ include "../shared/log.nginx" | indent 4 | trim }}
+    proxy_http_version 1.1;
+    proxy_pass http://backend;
+    proxy_redirect off;
+    proxy_set_header Connection "keep-alive";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}

--- a/examples/nginx.conf.in
+++ b/examples/nginx.conf.in
@@ -36,7 +36,7 @@ http {
         server_name localhost;
 
         root {{ .webroot | default "/usr/share/nginx/html" }};
-        index {{ "index.in" | regexReplaceAll "\\.in" ".html" }} index.htm;
+        index {{ "index.in" | reReplaceAll "\\.in" ".html" }} index.htm;
 
         {{ include "locations/api.nginx" | indent 8 | trim }}
 

--- a/examples/nginx.conf.in
+++ b/examples/nginx.conf.in
@@ -14,7 +14,7 @@ http {
 
     # Log
     access_log /var/logs/nginx/access.log
-  
+
     # Compression
     gzip on;
     gzip_http_version 1.1;
@@ -24,7 +24,7 @@ http {
     gzip_types application/x-javascript application/javascript application/xml text/javascript application/json text/json
     gzip_buffers 16 8k;
     gzip_disable "msie6";
-  
+
     # Tuning
     server_tokens off;
     sendfile on;
@@ -36,19 +36,10 @@ http {
         server_name localhost;
 
         root {{ .webroot | default "/usr/share/nginx/html" }};
-        index index.html index.htm;
+        index {{ "index.in" | regexReplaceAll "\\.in" ".html" }} index.htm;
 
-        location /api {
-            #access_log off;
-            proxy_http_version 1.1;
-            proxy_pass http://backend;
-            proxy_redirect off;
-            proxy_set_header Connection "keep-alive";
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        
+        {{ include "locations/api.nginx" | indent 8 | trim }}
+
         location /assets/ {
             root /var/webroot/assets;
             open_file_cache          max=10000 inactive=5m;

--- a/examples/shared/log.nginx
+++ b/examples/shared/log.nginx
@@ -1,0 +1,2 @@
+access_log off;
+log_format json_combined escape=json {{ include "./log_format.json" | nospace | squote }};

--- a/examples/shared/log_format.json
+++ b/examples/shared/log_format.json
@@ -1,0 +1,11 @@
+{
+  "time_local": "$time_local",
+  "remote_addr": "$remote_addr",
+  "remote_user": "$remote_user",
+  "request": "$request",
+  "status": "$status",
+  "body_bytes_sent": "$body_bytes_sent",
+  "request_time": "$request_time",
+  "http_referrer": "$http_referer",
+  "http_user_agent": "$http_user_agent"
+}

--- a/func.go
+++ b/func.go
@@ -36,9 +36,9 @@ func FuncMap(delims []string, file string, ctx interface{}) template.FuncMap {
 	oRegexReplaceAll := f["regexReplaceAll"].(func(regex string, s string, repl string) string)
 	oRegexReplaceAllLiteral := f["regexReplaceAllLiteral"].(func(regex string, s string, repl string) string)
 	oRegexSplit := f["regexSplit"].(func(regex string, s string, n int) []string)
-	f["regexReplaceAll"] = func(regex string, replacement string, input string) string { return oRegexReplaceAll(regex, input, replacement) }
-	f["regexReplaceAllLiteral"] = func(regex string, replacement string, input string) string { return oRegexReplaceAllLiteral(regex, input, replacement) }
-	f["regexSplit"] = func(regex string, n int, input string) []string { return oRegexSplit(regex, input, n) }
+	f["reReplaceAll"] = func(regex string, replacement string, input string) string { return oRegexReplaceAll(regex, input, replacement) }
+	f["reReplaceAllLiteral"] = func(regex string, replacement string, input string) string { return oRegexReplaceAllLiteral(regex, input, replacement) }
+	f["reSplit"] = func(regex string, n int, input string) []string { return oRegexSplit(regex, input, n) }
 	return f
 }
 

--- a/func.go
+++ b/func.go
@@ -32,6 +32,13 @@ func FuncMap(delims []string, file string, ctx interface{}) template.FuncMap {
 	f["fileGetString"] = fileGetString
 	// includes
 	f["include"] = include(delims, file, ctx)
+	// Fix sprig regex functions
+	oRegexReplaceAll := f["regexReplaceAll"].(func(regex string, s string, repl string) string)
+	oRegexReplaceAllLiteral := f["regexReplaceAllLiteral"].(func(regex string, s string, repl string) string)
+	oRegexSplit := f["regexSplit"].(func(regex string, s string, n int) []string)
+	f["regexReplaceAll"] = func(regex string, replacement string, input string) string { return oRegexReplaceAll(regex, input, replacement) }
+	f["regexReplaceAllLiteral"] = func(regex string, replacement string, input string) string { return oRegexReplaceAllLiteral(regex, input, replacement) }
+	f["regexSplit"] = func(regex string, n int, input string) []string { return oRegexSplit(regex, input, n) }
 	return f
 }
 

--- a/func.go
+++ b/func.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 )
 
-func FuncMap(delims []string, file string, ctx interface{}) template.FuncMap {
+func FuncMap(templateName string) template.FuncMap {
 	f := sprig.TxtFuncMap()
 	// marshal
 	f["toJson"] = toJson
@@ -30,8 +30,8 @@ func FuncMap(delims []string, file string, ctx interface{}) template.FuncMap {
 	f["fileLastModified"] = fileLastModified
 	f["fileGetBytes"] = fileGetBytes
 	f["fileGetString"] = fileGetString
-	// includes
-	f["include"] = include(delims, file, ctx)
+	// include
+	f["include"] = include(templateName)
 	// Fix sprig regex functions
 	oRegexReplaceAll := f["regexReplaceAll"].(func(regex string, s string, repl string) string)
 	oRegexReplaceAllLiteral := f["regexReplaceAllLiteral"].(func(regex string, s string, repl string) string)
@@ -157,7 +157,7 @@ func fileGetString(file string) string {
 
 type relativeInclude func(include string) string
 
-func include(delims []string, callingFile string, ctx interface{}) relativeInclude {
+func include(callingFile string) relativeInclude {
 	filePair := strings.SplitN(callingFile, ":", 2)
 	callingFile = filePair[0]
 
@@ -167,10 +167,8 @@ func include(delims []string, callingFile string, ctx interface{}) relativeInclu
 		}
 
 		t := template.New(includedFile)
-		if len(delims) == 2 {
-			t.Delims(delims[0], delims[1])
-		}
-		t.Funcs(FuncMap(delims, includedFile, ctx))
+		t.Delims(delims[0], delims[1])
+		t.Funcs(FuncMap(includedFile))
 
 		var err error
 		var templateBytes []byte

--- a/func.go
+++ b/func.go
@@ -29,47 +29,54 @@ func FuncMap() template.FuncMap {
 	return f
 }
 
-// toBool takes a string and converts it to a bool. It will
-// always return a bool, even on parsing error (false).
+// toBool takes a string and converts it to a bool.
+// On marshal error will panic if in strict mode, otherwise returns false.
 // It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
 //
 // This is designed to be called from a template.
 func toBool(value string) bool {
 	result, err := strconv.ParseBool(value)
 	if err != nil {
+		if Strict {
+			panic(err.Error())
+		}
 		return false
 	}
 	return result
 }
 
-// toJson takes an interface, marshals it to json, and returns a string. It will
-// always return a string, even on marshal error (empty string).
+// toJson takes an interface, marshals it to json, and returns a string.
+// On marshal error will panic if in strict mode, otherwise returns empty string.
 //
 // This is designed to be called from a template.
 func toJson(v interface{}) string {
 	data, err := json.Marshal(v)
 	if err != nil {
-		// Swallow errors inside of a template.
+		if Strict {
+			panic(err.Error())
+		}
 		return ""
 	}
 	return string(data)
 }
 
-// toYaml takes an interface, marshals it to yaml, and returns a string. It will
-// always return a string, even on marshal error (empty string).
+// toYaml takes an interface, marshals it to yaml, and returns a string.
+// On marshal error will panic if in strict mode, otherwise returns empty string.
 //
 // This is designed to be called from a template.
 func toYaml(v interface{}) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {
-		// Swallow errors inside of a template.
+		if Strict {
+			panic(err.Error())
+		}
 		return ""
 	}
 	return string(data)
 }
 
-// toToml takes an interface, marshals it to toml, and returns a string. It will
-// always return a string, even on marshal error (empty string).
+// toToml takes an interface, marshals it to toml, and returns a string.
+// On marshal error will panic if in strict mode, otherwise returns empty string.
 //
 // This is designed to be called from a template.
 func toToml(v interface{}) string {
@@ -77,7 +84,10 @@ func toToml(v interface{}) string {
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
 	if err != nil {
-		return err.Error()
+		if Strict {
+			panic(err.Error())
+		}
+		return ""
 	}
 	return b.String()
 }
@@ -85,8 +95,10 @@ func toToml(v interface{}) string {
 func fileSize(file string) int64 {
 	info, err := os.Stat(file)
 	if err != nil {
-		// Swallow errors inside of a template.
-		return -1
+		if Strict {
+			panic(err.Error())
+		}
+		return 0
 	}
 	return info.Size()
 }
@@ -94,7 +106,9 @@ func fileSize(file string) int64 {
 func fileLastModified(file string) time.Time {
 	info, err := os.Stat(file)
 	if err != nil {
-		// Swallow errors inside of a template.
+		if Strict {
+			panic(err.Error())
+		}
 		return time.Unix(0, 0)
 	}
 	return info.ModTime()
@@ -103,8 +117,10 @@ func fileLastModified(file string) time.Time {
 func fileGetBytes(file string) []byte {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		// Swallow errors inside of a template.
-		return nil
+		if Strict {
+			panic(err.Error())
+		}
+		return []byte{}
 	}
 	return data
 }
@@ -112,7 +128,9 @@ func fileGetBytes(file string) []byte {
 func fileGetString(file string) string {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		// Swallow errors inside of a template.
+		if Strict {
+			panic(err.Error())
+		}
 		return ""
 	}
 	return string(data)

--- a/func.go
+++ b/func.go
@@ -22,6 +22,7 @@ func FuncMap() template.FuncMap {
 	f["toToml"] = toToml
 	f["toBool"] = toBool
 	// file
+	f["fileExists"] = fileExists
 	f["fileSize"] = fileSize
 	f["fileLastModified"] = fileLastModified
 	f["fileGetBytes"] = fileGetBytes
@@ -90,6 +91,12 @@ func toToml(v interface{}) string {
 		return ""
 	}
 	return b.String()
+}
+
+func fileExists(file string) bool {
+	_, err := os.Stat(file)
+
+	return err == nil
 }
 
 func fileSize(file string) int64 {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ var (
 	Strict       bool
 )
 
+// template shared context
+var (
+	delims []string
+	ctx interface{}
+)
+
 // create template context
 func newTemplateVariables() map[string]interface{} {
 
@@ -105,7 +111,7 @@ func newTemplateVariables() map[string]interface{} {
 	return vars
 }
 
-func templateExecute(t *template.Template, file string, ctx interface{}) {
+func templateExecute(t *template.Template, file string) {
 	filePair := strings.SplitN(file, ":", 2)
 	srcFile := filePair[0]
 	destFile := ""
@@ -243,11 +249,12 @@ echo "{{ .Env.PATH }}"  | frep -
 			}
 		}()
 
-		delims := strings.Split(Delims, ":")
+		delims = strings.Split(Delims, ":")
 		if len(Delims) < 3 || len(delims) != 2 {
 			panic(fmt.Errorf("bad delimiters argument: %s. expected \"left:right\"", Delims))
 		}
 
+		ctx = newTemplateVariables()
 		for _, file := range c.Args() {
 			filePair := strings.SplitN(file, ":", 2)
 			srcFile := filePair[0]
@@ -255,9 +262,8 @@ echo "{{ .Env.PATH }}"  | frep -
 			t := template.New(srcFile)
 			t.Delims(delims[0], delims[1])
 
-			vars := newTemplateVariables()
-			t.Funcs(FuncMap(delims, file, vars))
-			templateExecute(t, file, vars)
+			t.Funcs(FuncMap(file))
+			templateExecute(t, file)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -243,18 +243,20 @@ echo "{{ .Env.PATH }}"  | frep -
 			}
 		}()
 
-		t := template.New("noname").Funcs(FuncMap())
-		if Delims != "" {
-			pairs := strings.Split(Delims, ":")
-			if len(pairs) != 2 {
-				panic(fmt.Errorf("bad delimiters argument: %s. expected \"left:right\"", Delims))
-			}
-			t = t.Delims(pairs[0], pairs[1])
+		delims := strings.Split(Delims, ":")
+		if len(Delims) < 3 || len(delims) != 2 {
+			panic(fmt.Errorf("bad delimiters argument: %s. expected \"left:right\"", Delims))
 		}
 
-		vars := newTemplateVariables()
-
 		for _, file := range c.Args() {
+			filePair := strings.SplitN(file, ":", 2)
+			srcFile := filePair[0]
+
+			t := template.New(srcFile)
+			t.Delims(delims[0], delims[1])
+
+			vars := newTemplateVariables()
+			t.Funcs(FuncMap(delims, file, vars))
 			templateExecute(t, file, vars)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	Dryrun       bool
 	NoSysEnv     bool
 	Delims       string
+	Strict       bool
 )
 
 // create template context
@@ -199,6 +200,11 @@ func main() {
 			Name:  "dryrun",
 			Usage: "just output result to console instead of file",
 			Value: &Dryrun,
+		},
+		{
+			Name:  "strict",
+			Usage: "exit on any error during template processing",
+			Value: &Strict,
 		},
 		{
 			Name:     "delims",


### PR DESCRIPTION
Couple different changes I've been using in my own build for a while, not sure if they are useful to you, but figured I'd send them over.

I've been bitten a few times by marshaling errors being silently ignored, but figure the behavior might still be desired by some so having it as an option seems to make the most sense.

Might be a cleaner way to handle the regex functions, but works well enough for my needs and my limited time writing Go.