### PR TITLE
Change secretsmanager package used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,13 @@ require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/aws/aws-sdk-go v1.30.10
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/overdrive3000/secretsmanager v0.1.1-0.20200426141521-452d7b152805
+	github.com/overdrive3000/secretsmanager v0.2.0
 	github.com/subchen/go-cli v2.0.0+incompatible
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITg
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
-github.com/aws/aws-sdk-go v1.30.5 h1:i+sSesaMrSxiUt3NJddOApe2mXK+VNBgfcmRTvNFrXM=
-github.com/aws/aws-sdk-go v1.30.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.10 h1:Je2O8GgAwqDGVN2Da+B1PbNXYhkOO/AcNhuTd9llKGk=
 github.com/aws/aws-sdk-go v1.30.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -32,10 +30,8 @@ github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMK
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/overdrive3000/secretsmanager v0.1.0 h1:Ke5gJ1hR/fGgm+BuCrvFQ0qEKtMw9Td54KxBaMpAYWE=
-github.com/overdrive3000/secretsmanager v0.1.0/go.mod h1:KD0dEc9SA7LxlpoG8PPJOYtDS9yaZ7QTRi38YUlLJ0o=
-github.com/overdrive3000/secretsmanager v0.1.1-0.20200426141521-452d7b152805 h1:+b2GAiXOZ/3u0DLgq2HbWq5XSOJU0WV31vokGwgudhw=
-github.com/overdrive3000/secretsmanager v0.1.1-0.20200426141521-452d7b152805/go.mod h1:KD0dEc9SA7LxlpoG8PPJOYtDS9yaZ7QTRi38YUlLJ0o=
+github.com/overdrive3000/secretsmanager v0.2.0 h1:yttRMzBRg2z05JVVPQYSapnvA93hnm83B49mNr2B9eM=
+github.com/overdrive3000/secretsmanager v0.2.0/go.mod h1:KD0dEc9SA7LxlpoG8PPJOYtDS9yaZ7QTRi38YUlLJ0o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Hi @subchen

I can notice you just merged my previous PR, thank you so much about that.

I just like to add a simple change as I've changed the tag version of the secretsmanager package I am using (https://github.com/overdrive3000/secretsmanager).

Tested and merge conflicts are solved.

It would be great if you merge this.

Thank you.