### PR TITLE
new feature, get params from SSM Parameter Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ More [funcs](https://github.com/subchen/frep/blob/master/func.go) added:
     - reReplaceAllLiteral
     - reSplit
 - awsSecret
+- awsParameterStore
 
 Sample of nginx.conf.in
 
@@ -277,3 +278,19 @@ mysql_pass: {{ awsSecret "application/mysql/password" }}
 external_api_client: {{ awsSecret "application/external_api" "client_id" }}
 external_api_secret: {{ awsSecret "application/external_api" "secret_key" }}
 ```
+
+Sample using AWS Parameter Store, first of all take into account that in order to use the ssm functionality you need to have a proper AWS configuration in place and permissions enough to read parameters from AWS Parameter Store. More details of how to configure AWSCLI can be found at https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html 
+
+Once you have all the requirements just create a template like this one:
+
+```
+# application.conf
+mysql_host: {{ .mysql_host }}
+mysql_user: {{ .mysql_user }}
+mysql_pass: {{ awsSecret "application/mysql/password" }}
+mysql_dns: {{ awsParameterStore "application/mysql/dns" }}
+```
+In above example `mysql_dns` will be filled as usual by using `frep` config file or environment variables but `mysql_pass` will be fetch straight from AWS Parameter Store by looking at `application/mysql/dns`
+
+SSM Limitation: You can get parameter from ParameterStore just in textplain.
+

--- a/func.go
+++ b/func.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig"
 	"github.com/go-yaml/yaml"
+	"github.com/ismferd/ssm/package/parameterstore"
 	"github.com/overdrive3000/secretsmanager"
 )
 
@@ -56,6 +57,7 @@ func FuncMap(templateName string) template.FuncMap {
 
 	// Add function to get secrets from AWS Secrets Manager
 	f["awsSecret"] = getAWSSecret
+	f["awsParameterStore"] = getAWSParameterStore
 
 	return f
 }
@@ -90,6 +92,29 @@ func getAWSSecret(secret ...string) string {
 	}
 
 	return s
+}
+
+// getAWSParameterStore return a parameter stored in AWS SSM Parameter Store.
+// function accepts as parameter a names.
+func getAWSParameterStore(parameter string) string {
+
+	c := parameterstore.New(
+		&parameterstore.AWSConfig{},
+	)
+
+	spec := &parameterstore.ParemeterString{
+		Name: parameter,
+	}
+
+	p, err := c.GetParam(spec)
+	if err != nil {
+		if Strict {
+			panic(err)
+		}
+		return ""
+	}
+
+	return p
 }
 
 // toBool takes a string and converts it to a bool.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/ismferd/ssm v0.1.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/overdrive3000/secretsmanager v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZC
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/aws/aws-sdk-go v1.30.10 h1:Je2O8GgAwqDGVN2Da+B1PbNXYhkOO/AcNhuTd9llKGk=
 github.com/aws/aws-sdk-go v1.30.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.30.29 h1:NXNqBS9hjOCpDL8SyCyl38gZX3LLLunKOJc5E7vJ8P0=
+github.com/aws/aws-sdk-go v1.30.29/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -19,6 +21,10 @@ github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/ismferd/ssm v0.0.0-20200517084015-888107c4c109 h1:xpg69WF9Lh+lC1pJByXu42CrDMmMCL8Mw4aHM6USyDM=
+github.com/ismferd/ssm v0.0.0-20200517084015-888107c4c109/go.mod h1:EWSM3Tffi8r6sdVC0/E8Tudbgp4MEhDHn52prrxYJpQ=
+github.com/ismferd/ssm v0.1.0 h1:5pHLTEhdzeE3JLIbgF/221uoDdhhbN+0CNz9KQtJvVY=
+github.com/ismferd/ssm v0.1.0/go.mod h1:EWSM3Tffi8r6sdVC0/E8Tudbgp4MEhDHn52prrxYJpQ=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
This PR add a custom function that is added to the FuncMap map in order to be able to fetch parameters from AWS Parameter Store.

We are using frep as potential tool to generate our config files from template to file, so we need to start using AWS SSM Parameter Store through frep in order to centralize our parameters using frep as middleware as well.

Hope this PR likes you and become part of the main frep project, thank you so much for this tool.